### PR TITLE
fix isset call on PHP5

### DIFF
--- a/admin/include/editing.inc.php
+++ b/admin/include/editing.inc.php
@@ -190,7 +190,8 @@ function edit_type($key, $field, $collations, $foreign_keys = [], $extra_types =
 	$type = $field["type"] ?? null;
 	?>
 <td><select name="<?php echo h($key); ?>[type]" class="type" aria-labelledby="label-type"><?php
-if ($type && !isset(Driver::get()->getTypes()[$type]) && !isset($foreign_keys[$type]) && !in_array($type, $extra_types)) {
+$driverTypes = Driver::get()->getTypes();
+if ($type && !isset($driverTypes[$type]) && !isset($foreign_keys[$type]) && !in_array($type, $extra_types)) {
 	$extra_types[] = $type;
 }
 $structured_types = Driver::get()->getStructuredTypes();


### PR DESCRIPTION
This was forbidden in PHP5

<img width="558" height="106" alt="Screenshot_20250906_153427" src="https://github.com/user-attachments/assets/ea7f3e70-6b99-480e-a783-4b2be5f40110" />
